### PR TITLE
Improved tracking of benchmarking services

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -17,6 +17,8 @@ left:
 by-use:
   - title: General
     url: /by-use/general
+  - title: Benchmarking
+    url: /by-use/benchmarking
   - title: Worker Pools
     children:
       - title: Linux-x86_64
@@ -53,6 +55,8 @@ by-location:
         url: /by-location/custodian
       - title: Marist College
         url: /by-location/marist-college
+      - title: IIT Madras
+        url: /by-location/iitm
 
 by-ip:
   - title: Subnets

--- a/_includes/use-table.html
+++ b/_includes/use-table.html
@@ -1,0 +1,26 @@
+
+<table>
+<tr>
+<th>Machine</th>
+<th>Model</th>
+<th>OS</th>
+<th>Threads</th>
+<th>Location</th>
+<th>Service</th>
+</tr>
+{% assign lower_title = page.title | downcase %}
+{% for item in site.machines %}
+{% assign lower_use = item.use | downcase %}
+{% if lower_use == lower_title %}
+<tr>
+<td><a href="/{{item.path | replace: "_machines", "machines" | replace: ".md", ".html"}}">{{item.name}}</a></td>
+<td>{{item.manufacturer}} {{item.model}}</td>
+<td>{{item.os}}</td>
+<td>{{item.threads}}</td>
+<td>{{item.location}}</td>
+<td>{{item.service}}</td>
+</tr>
+{% endif %}
+{% endfor %}
+</table>
+

--- a/_machines/navajo.md
+++ b/_machines/navajo.md
@@ -8,6 +8,8 @@ processor: AMD EPYC 7551 32-Core Processor
 os: Ubuntu 20.04
 threads: 128
 location: Caelum
+use: benchmarking
+service: Sandmark Nightly
 notes: Benchmark Tooling Team.  Sandmark benchmarking.
 serial: 7NCSYQ2
 ssh: mte24@navajo.ocamllabs.io

--- a/_machines/roo.md
+++ b/_machines/roo.md
@@ -2,10 +2,12 @@
 name: roo
 ip: 128.232.124.253
 fqdn: roo.ocamllabs.io
-notes: Benchmarking -- fermat.ocamllabs.io
+notes: Benchmarking -- fermat.ocamllabs.io -- parallel benchmarks
 manufacturer: SuperMicro
 model: h8qg6/h8qgi
 location: Caelum
+use: benchmarking
+service: current-bench
 threads: 48
 memory: 64GB
 processor: AMD Opteron Processor 6344

--- a/_machines/spring.md
+++ b/_machines/spring.md
@@ -6,6 +6,8 @@ model: Super Server
 os: Ubuntu 20.04
 threads: 8
 location: Caelum
+use: benchmarking
+service: current-bench
 notes: Docker containers with GraphQL and current-bench
 serial: 0123456789
 processor: 'Intel(R) Xeon(R) Silver 4108 CPU @ 1.80GHz'

--- a/_machines/turing.md
+++ b/_machines/turing.md
@@ -7,6 +7,8 @@ processor: Intel(R) Xeon(R) Gold 5120 CPU @ 2.20GHz
 os: Ubuntu 20.04.5 LTS
 threads: 28
 location: IIT Madras
+use: benchmarking
+service: Sandmark Nightly
 notes: Benchmarking Team -- Used for Sandmark; requires ZeroTier connection
 serial: 4YGD013
 ---

--- a/_machines/winter.md
+++ b/_machines/winter.md
@@ -6,6 +6,8 @@ model: Super Server
 os: Ubuntu 18.04
 threads: 16
 location: Caelum
+use: benchmarking
+service: Sandmark
 notes: General purpose machine, typically for benchmarking by compiler developers.  Primary users nickbarnes, polytypic, fabrice, sadiq, shakthi
 serial: NM18CS008836
 processor: 'Intel(R) Xeon(R) Silver 4108 CPU @ 1.80GHz'

--- a/by-location/iitm.md
+++ b/by-location/iitm.md
@@ -1,0 +1,8 @@
+---
+title: IIT Madras
+---
+
+{% include location-table.html %} 
+
+
+

--- a/by-use/benchmarking.md
+++ b/by-use/benchmarking.md
@@ -1,0 +1,6 @@
+---
+title: Benchmarking
+---
+
+{% include use-table.html %} 
+


### PR DESCRIPTION
This PR adds a new template page `use-table.md` which uses the title of the page to filter by `use` of the machine.
This template page is used by the new `by-use/benchmarking.md` which thus tracks the machines used for benchmarking.
The benchmarking machines have been marked with `use: benchmarking` to track them in a standardized way.
The `use-table.md` also includes a row **Service** intended to show the service running on the machine. I've marked the benchmarking machines accordingly. 
In addition, I've included the missing `by-location/iitm.md` for machines hosted at IIT Madras.

cc: @mtelvers 