### PR TITLE
Update service details on autumn and spring

### DIFF
--- a/_machines/autumn.md
+++ b/_machines/autumn.md
@@ -11,5 +11,6 @@ notes: Benchmarking team.  Current-bench and OCaml benchmarking projects.
 serial: NM18CS008840
 ssh: mte24@autumn.ocamllabs.io
 use: benchmarking
+service: current-bench
 ---
 {% include details.html %}

--- a/_machines/spring.md
+++ b/_machines/spring.md
@@ -7,7 +7,6 @@ os: Ubuntu 20.04
 threads: 8
 location: Caelum
 use: benchmarking
-service: current-bench
 notes: Benchmarking Spare
 serial: 0123456789
 processor: 'Intel(R) Xeon(R) Silver 4108 CPU @ 1.80GHz'


### PR DESCRIPTION
Autumn was missing current-bench as service, whereas spring incorrectly had it.