### PR TITLE
Updated benchmarking machines to Ubuntu 22.04.3 LTS

### DIFF
--- a/_machines/autumn.md
+++ b/_machines/autumn.md
@@ -4,7 +4,7 @@ ip: 128.232.124.187
 fqdn: autumn.ocamllabs.io
 model: Super Server
 processor: Intel(R) Xeon(R) Silver 4108 CPU @ 1.80GHz
-os: Ubuntu 18.04.3
+os: Ubuntu 22.04.3 LTS
 threads: 8
 location: Caelum
 notes: Benchmarking team.  Current-bench and OCaml benchmarking projects.

--- a/_machines/bremusa.md
+++ b/_machines/bremusa.md
@@ -5,7 +5,7 @@ fqdn: bremusa.ocamllabs.io
 manufacturer: Dell
 model: PowerEdge R630
 serial: DLDZGL2
-os: Ubuntu 20.04.3
+os: Ubuntu 22.04.3 LTS
 threads: 72
 notes: Benchmarking. /dev/sdb is unused
 location: Caelum

--- a/_machines/navajo.md
+++ b/_machines/navajo.md
@@ -5,7 +5,7 @@ fqdn: navajo.ocamllabs.io
 manufacturer: Dell
 model: PowerEdge R7425
 processor: AMD EPYC 7551 32-Core Processor
-os: Ubuntu 20.04
+os: Ubuntu 22.04.3 LTS
 threads: 128
 location: Caelum
 use: benchmarking

--- a/_machines/roo.md
+++ b/_machines/roo.md
@@ -5,6 +5,7 @@ fqdn: roo.ocamllabs.io
 notes: Benchmarking -- fermat.ocamllabs.io -- parallel benchmarks
 manufacturer: SuperMicro
 model: h8qg6/h8qgi
+os: Ubuntu 22.04.3 LTS
 location: Caelum
 use: benchmarking
 service: current-bench

--- a/_machines/turing.md
+++ b/_machines/turing.md
@@ -4,7 +4,7 @@ ip: 10.147.20.85
 fqdn: turing.ocamllabs.io
 model: Precision 7820 Tower
 processor: Intel(R) Xeon(R) Gold 5120 CPU @ 2.20GHz
-os: Ubuntu 20.04.5 LTS
+os: Ubuntu 22.04.3 LTS
 threads: 28
 location: IIT Madras
 use: benchmarking

--- a/_machines/winter.md
+++ b/_machines/winter.md
@@ -3,7 +3,7 @@ name: winter
 ip: 128.232.124.181
 fqdn: winter.ocamllabs.io
 model: Super Server
-os: Ubuntu 18.04
+os: Ubuntu 22.04.3 LTS
 threads: 16
 location: Caelum
 use: benchmarking


### PR DESCRIPTION
Updated Ubuntu 22.04.3 LTS versions on benchmarking servers.