### PR TITLE
Announce plans to move updates to the OCaml Changelog

### DIFF
--- a/_posts/2024-10-02-moving-updates.md
+++ b/_posts/2024-10-02-moving-updates.md
@@ -1,0 +1,13 @@
+---
+title: "Moving updates to ocaml.org"
+date: "2024-10-02"
+---
+
+Going forward, we will be publishing updates to the [OCaml
+Changelog](https://ocaml.org/changelog), under the ['infrastructure'
+tag](https://ocaml.org/changelog?t=infrastructure). This aggregation of
+communications reflects the critical role of the infrastructure in supporting
+the ocaml ecosystem, and we expect it to improve dissemination by reducing the
+number of streams interested readers need to monitor. We have a basket of
+(overdue) updates to announce, so be on the lookout for that in your browser or
+RSS reader!


### PR DESCRIPTION
We are planning to renew (and redouble) or public updates on infrastructure events and activities. However, we think it would be valuable to target these updates at the OCaml Changelog, rather than leaving them isolated on infra.ocaml.org. The rationale for this is described in the body of the announcement post proposed this PR.

I am drafting an update targeting ocaml.org, and will link that from this issue for reference when ready.

Comments and questions welcome!

cc @punchagan (whom I cannot tag in for review :) ).